### PR TITLE
Apply pre-stage hook within models/format API call

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -33,6 +33,7 @@ database = %(db)s/wmt.db
 user_db = %(db)s/users.db
 submission_db = %(db)s/submission.db
 db = db
+tmp = tmp
 
 [url]
 scheme = {url_scheme}
@@ -323,7 +324,8 @@ def install_wmt_api(prefix, dir='.'):
             prefix, python_site_packages(which_python())))
 
     with cd(prefix):
-        for path in ['bin', 'conf', 'db', 'files/uploads', 'files/downloads']:
+        for path in ['bin', 'conf', 'db', 'files/uploads',
+                     'files/downloads', 'tmp']:
             mkpath(path)
 
     with cd(os.path.join(prefix, 'opt', 'wmt-api')):

--- a/wmt/models/submissions.py
+++ b/wmt/models/submissions.py
@@ -2,6 +2,7 @@ import web
 import os
 from uuid import uuid4
 import json
+import shutil
 
 from . import components, models
 from ..config import submission_db as db
@@ -243,7 +244,7 @@ def prepend_to_path(envvar, path):
     os.environ[envvar] = os.pathsep.join(paths)
 
 
-def stage_component(component, prefix='.'):
+def stage_component(component, prefix='.', prestage_only=False):
     # name = component['class'].lower()
     name = component['class']
     stage_dir = os.path.abspath(os.path.join(prefix, name))
@@ -257,6 +258,10 @@ def stage_component(component, prefix='.'):
 
     with execute_in_dir(stage_dir) as _:
         hooks['pre-stage'].execute(component['parameters'])
+
+    if prestage_only:
+        shutil.rmtree(stage_dir)
+        return
 
     with execute_in_dir(stage_dir) as _:
         _component_stagein(component)


### PR DESCRIPTION
I modified wmt.models.submissions.stage_component() to apply the pre-stage hook (the only one we've been using) when the models/format API call is made. The files displayed by models/format then include any modifications made in the hook, which can be substantial--see, e.g., the Topoflow components.

This fixes #95, but narrowly. I haven't considered applying the post-stage hook, mostly because I don't think there's a component in WMT that has one.