### PR TITLE
Create a visualization API

### DIFF
--- a/wmt/__init__.py
+++ b/wmt/__init__.py
@@ -78,6 +78,7 @@ URLS = (
     '/run/(%s)' % _UUID_REGEX, 'wmt.controllers.run.Get',
     '/run/(%s)/status' % _UUID_REGEX, 'wmt.controllers.run.Status',
     '/run/', 'wmt.controllers.run.GetAll',
+    '/run/visualize', 'wmt.controllers.run.Visualize',
 
     '/hosts/new', 'wmt.controllers.hosts.New',
     '/hosts/view/(\d+)', 'wmt.controllers.hosts.View',

--- a/wmt/controllers/run.py
+++ b/wmt/controllers/run.py
@@ -8,6 +8,7 @@ from ..validators import (not_too_long, not_too_short, not_bad_json,
                           valid_uuid, submission_exists, model_exists)
 from ..cca import rc_from_json
 from ..utils.io import chunk_copy
+from ..utils.ssh import pickup_url
 from ..config import logger, site
 from ..utils.ssh import launch_cmt_on_host
 
@@ -409,3 +410,46 @@ class Show(object):
         ]
         return render.statustable(statuses)
         # return render.statustable(submissions.get_submissions())
+
+
+class Visualize(object):
+
+    form = web.form.Form(
+        web.form.Textbox('uuid',
+                         valid_uuid,
+                         submission_exists(),
+                         size=80, description='Simulation id:'),
+        web.form.Textbox('component',
+                         not_too_long(512),
+                         size=80, description='Component:'),
+        web.form.Textbox('filepath',
+                         not_too_long(512),
+                         size=80, description='Filepath:'),
+        web.form.Button('Visualize')
+    )
+
+    error_message = """Unable to visualize simulation results. This is
+either a bad simulation UUID or the simulation has not yet been
+staged."""
+
+    def GET(self):
+        return render.titled_form('Visualize Simulation Output', self.form())
+
+    def POST(self):
+        import tarfile
+
+        form = self.form()
+        if not form.validates():
+            raise web.internalerror(self.error_message)
+
+        if not os.path.isdir(os.path.join(site['pickup'], form.d.uuid)):
+            tarball = form.d.uuid + '.tar.gz'
+            os.chdir(site['pickup'])
+            with tarfile.open(tarball) as tar:
+                tar.extractall()
+
+        visualize_url = os.path.join(pickup_url(),
+                                     form.d.uuid,
+                                     form.d.component,
+                                     form.d.filepath)
+        web.seeother(visualize_url)

--- a/wmt/data/templates/status.html
+++ b/wmt/data/templates/status.html
@@ -1,7 +1,7 @@
 $def with (title, submission)
 
 <head>
-  <meta http-equiv="refresh" content="2"/>
+  <meta http-equiv="refresh" content="10"/>
 </head>
 
 <h1>$submission.name</h1>

--- a/wmt/utils/ssh.py
+++ b/wmt/utils/ssh.py
@@ -14,6 +14,13 @@ def site_url():
     return urlparse.urlunsplit(parts)
 
 
+def pickup_url():
+    import urlparse
+    parts = (site['pickup_scheme'], site['pickup_netloc'],
+             site['pickup_path'], '', '')
+    return urlparse.urlunsplit(parts)
+
+
 def open_connection_to_host(host, username, password=None, onerror='raise'):
     assert(onerror in ['raise', 'prompt'])
 


### PR DESCRIPTION
Since WMT is web-based, it should be possible to display graphics generated as a result of a simulation in a browser. The *run/visualize* API call takes the uuid of a completed simulation, a component name, and a path to a file in the component directory, and displays it in a browser window.