### PR TITLE
Delete simulation output from status page

### DIFF
--- a/wmt/__init__.py
+++ b/wmt/__init__.py
@@ -65,6 +65,7 @@ URLS = (
 
     '/run/new', 'wmt.controllers.run.New',
     '/run/delete/(%s)' % _UUID_REGEX, 'wmt.controllers.run.Delete',
+    '/run/delete/ui/(%s)' % _UUID_REGEX, 'wmt.controllers.run.UiDelete',
     '/run/show', 'wmt.controllers.run.Show',
     '/run/status', 'wmt.controllers.run.Status',
     '/run/stage', 'wmt.controllers.run.Stage',
@@ -77,8 +78,6 @@ URLS = (
     '/run/(%s)' % _UUID_REGEX, 'wmt.controllers.run.Get',
     '/run/(%s)/status' % _UUID_REGEX, 'wmt.controllers.run.Status',
     '/run/', 'wmt.controllers.run.GetAll',
-
-    '/run/delete/ui/(%s)' % _UUID_REGEX, 'wmt.controllers.run.UiDelete',
 
     '/hosts/new', 'wmt.controllers.hosts.New',
     '/hosts/view/(\d+)', 'wmt.controllers.hosts.View',

--- a/wmt/controllers/run.py
+++ b/wmt/controllers/run.py
@@ -178,13 +178,15 @@ class UiDelete(object):
         return render.confirm_delete(form)
 
     def POST(self, uuid):
-        form = self.form()
-        #form.fill(uuid=uuid)
-        #if not form.validates():
-        #    return render.confirm_delete(form)
-
         submissions.delete(uuid)
-        raise web.seeother('/run/show')
+        os.chdir(site['pickup'])
+        tarball = uuid + '.tar.gz'
+        try:
+            os.remove(tarball)
+        except:
+            pass
+        finally:
+            raise web.seeother('/run/show')
 
 
 class Delete(object):

--- a/wmt/controllers/run.py
+++ b/wmt/controllers/run.py
@@ -39,6 +39,15 @@ def launch_simulation(uuid, username, host, password):
             message='unexpected error launching simulation on %s (%d: %s)' % (host, resp['status_code'], resp['stderr']))
 
 
+def delete_output(uuid):
+    os.chdir(site['pickup'])
+    tarball = uuid + '.tar.gz'
+    try:
+        os.remove(tarball)
+    except:
+        pass
+
+
 def parse_submission_status(status):
     import yaml
 
@@ -179,14 +188,8 @@ class UiDelete(object):
 
     def POST(self, uuid):
         submissions.delete(uuid)
-        os.chdir(site['pickup'])
-        tarball = uuid + '.tar.gz'
-        try:
-            os.remove(tarball)
-        except:
-            pass
-        finally:
-            raise web.seeother('/run/show')
+        delete_output(uuid)
+        raise web.seeother('/run/show')
 
 
 class Delete(object):


### PR DESCRIPTION
This PR addresses the first part of #84. Now, when a user clicks the trashcan icon on the status page, in addition to removing the submission, the simulation tarball is also deleted.