### PR TITLE
Make visualize file API

### DIFF
--- a/wmt/__init__.py
+++ b/wmt/__init__.py
@@ -78,6 +78,7 @@ URLS = (
     '/run/(%s)' % _UUID_REGEX, 'wmt.controllers.run.Get',
     '/run/(%s)/status' % _UUID_REGEX, 'wmt.controllers.run.Status',
     '/run/', 'wmt.controllers.run.GetAll',
+    '/run/visualize', 'wmt.controllers.run.Visualize',
 
     '/hosts/new', 'wmt.controllers.hosts.New',
     '/hosts/view/(\d+)', 'wmt.controllers.hosts.View',

--- a/wmt/__init__.py
+++ b/wmt/__init__.py
@@ -79,6 +79,7 @@ URLS = (
     '/run/(%s)/status' % _UUID_REGEX, 'wmt.controllers.run.Status',
     '/run/', 'wmt.controllers.run.GetAll',
     '/run/visualize', 'wmt.controllers.run.Visualize',
+    '/run/visualize/(%s)' % _UUID_REGEX, 'wmt.controllers.run.VisualizeFile',
 
     '/hosts/new', 'wmt.controllers.hosts.New',
     '/hosts/view/(\d+)', 'wmt.controllers.hosts.View',

--- a/wmt/controllers/run.py
+++ b/wmt/controllers/run.py
@@ -8,6 +8,7 @@ from ..validators import (not_too_long, not_too_short, not_bad_json,
                           valid_uuid, submission_exists, model_exists)
 from ..cca import rc_from_json
 from ..utils.io import chunk_copy
+from ..utils.ssh import pickup_url
 from ..config import logger, site
 from ..utils.ssh import launch_cmt_on_host
 
@@ -409,3 +410,46 @@ class Show(object):
         ]
         return render.statustable(statuses)
         # return render.statustable(submissions.get_submissions())
+
+
+class Visualize(object):
+
+    form = web.form.Form(
+        web.form.Textbox('uuid',
+                         valid_uuid,
+                         submission_exists(),
+                         size=80, description='Simulation id:'),
+        web.form.Textbox('component',
+                         not_too_long(512),
+                         size=80, description='Component:'),
+        web.form.Textbox('filepath',
+                         not_too_long(512),
+                         size=80, description='Filepath:'),
+        web.form.Button('Visualize')
+    )
+
+    error_message = """Unable to visualize simulation results. This is
+either a bad simulation UUID or the simulation has not yet been
+staged."""
+
+    def GET(self):
+        return render.titled_form('Visualize Simulation Output', self.form())
+
+    def POST(self):
+        import tarfile
+
+        form = self.form()
+        if not form.validates():
+            raise web.internalerror(self.error_message)
+
+        if not os.path.isdir(os.path.join(site['pickup'], form.d.uuid)):
+            tarball = form.d.uuid + '.tar.gz'
+            os.chdir(site['pickup'])
+            with tarfile.open(tarball) as tar:
+                tar.extractall()
+
+        visualize_url = os.path.join(pickup_url(),
+                                     form.d.uuid,
+                                     form.d.component,
+                                     form.d.filepath)
+        web.seeother(visualize_url)

--- a/wmt/controllers/run.py
+++ b/wmt/controllers/run.py
@@ -453,3 +453,40 @@ staged."""
                                      form.d.component,
                                      form.d.filepath)
         web.seeother(visualize_url)
+
+
+class VisualizeFile(object):
+
+    error_message = """Unable to visualize simulation results. This is
+either because the simulation has not completed, or the simulation
+contains no visualization."""
+
+    def GET(self, uuid):
+        import tarfile
+
+        info = submissions.get_submission(uuid)
+        driver = models.get_model_driver(info['model_id'])
+
+        tarball = uuid + '.tar.gz'
+        os.chdir(site['pickup'])
+        try:
+            with tarfile.open(tarball) as tar:
+                tar.extractall()
+        except IOError:
+            pass
+        except:
+            raise web.internalerror(self.error_message)
+
+        try:
+            driver['parameters']['_visualization']
+        except KeyError:
+            visualize_url = os.path.join(pickup_url(),
+                                         uuid,
+                                         driver['id'])
+        else:
+            visualize_url = os.path.join(pickup_url(),
+                                         uuid,
+                                         driver['id'],
+                                         driver['parameters']['_visualization'])
+
+        web.seeother(visualize_url)

--- a/wmt/data/templates/status.html
+++ b/wmt/data/templates/status.html
@@ -47,6 +47,10 @@ $if submission.status == 'success':
      class="btn btn-lg btn-success btn-block" role="button">
     <span class="glyphicon glyphicon-cloud-download fa-lg"></span>
   </a>
+  <a href="$PREFIX/run/visualize/${submission.uuid}"
+     class="btn btn-lg btn-success btn-block" role="button">
+    <span class="glyphicon glyphicon-stats fa-lg"></span>
+  </a>
 
 <a href="$PREFIX/run/show"
    class="btn btn-lg btn-block btn-default" role="button">The Rest...

--- a/wmt/data/templates/status.html
+++ b/wmt/data/templates/status.html
@@ -49,7 +49,7 @@ $if submission.status == 'success':
   </a>
   <a href="$PREFIX/run/visualize/${submission.uuid}"
      class="btn btn-lg btn-success btn-block" role="button">
-    <span class="glyphicon glyphicon-stats fa-lg"></span>
+    <span class="glyphicon glyphicon-eye-open fa-lg"></span>
   </a>
 
 <a href="$PREFIX/run/show"

--- a/wmt/data/templates/statustable.html
+++ b/wmt/data/templates/statustable.html
@@ -14,7 +14,7 @@ $def with (submissions)
       <th width="50px" scope="col"></th>
       <th width="50px" scope="col"></th-->
       <!--th scope="col"></th-->
-      <th width="150px" scope="col"></th>
+      <th width="120px" scope="col"></th>
     </thead>
     <tbody>
     $for submission in submissions:
@@ -111,6 +111,10 @@ $def with (submissions)
 
 	    <a href="$PREFIX/run/delete/ui/${submission.uuid}" class="btn btn-link">
 	      <span class="glyphicon glyphicon-trash fa-lg"></span>
+	    </a>
+
+	    <a href="$PREFIX/run/visualize/${submission.uuid}" class="btn btn-link">
+	      <span class="glyphicon glyphicon-stats fa-lg"></span>
 	    </a>
 
 	  </div>

--- a/wmt/data/templates/statustable.html
+++ b/wmt/data/templates/statustable.html
@@ -114,7 +114,7 @@ $def with (submissions)
 	    </a>
 
 	    <a href="$PREFIX/run/visualize/${submission.uuid}" class="btn btn-link">
-	      <span class="glyphicon glyphicon-stats fa-lg"></span>
+	      <span class="glyphicon glyphicon-eye-open fa-lg"></span>
 	    </a>
 
 	  </div>

--- a/wmt/models/models.py
+++ b/wmt/models/models.py
@@ -105,6 +105,13 @@ def get_model_component(id, component):
     raise KeyError(component)
 
 
+def get_model_driver(id):
+    model = json.loads(get_model(id)['json'])
+    for item in model['model']:
+        if item['driver']:
+            return item
+
+
 def get_model_yaml(id):
     import yaml
 

--- a/wmt/utils/ssh.py
+++ b/wmt/utils/ssh.py
@@ -14,6 +14,13 @@ def site_url():
     return urlparse.urlunsplit(parts)
 
 
+def pickup_url():
+    import urlparse
+    parts = (site['pickup_scheme'], site['pickup_netloc'],
+             site['pickup_path'], '', '')
+    return urlparse.urlunsplit(parts)
+
+
 def open_connection_to_host(host, username, password=None, onerror='raise'):
     assert(onerror in ['raise', 'prompt'])
 


### PR DESCRIPTION
Since WMT is web-based, it should be possible to display graphics generated as a result of a simulation in a browser. The *run/visualize* API call takes the uuid of a completed simulation, a component name, and a path to a file in the component directory, and displays it in a browser window.