### PR TITLE
Add new API calls for making and deleting tarballs

### DIFF
--- a/wmt/__init__.py
+++ b/wmt/__init__.py
@@ -81,6 +81,8 @@ URLS = (
     '/run/visualize', 'wmt.controllers.run.Visualize',
     '/run/visualize/(%s)' % _UUID_REGEX, 'wmt.controllers.run.VisualizeFile',
 
+    '/package/create', 'wmt.controllers.package.Create',
+
     '/hosts/new', 'wmt.controllers.hosts.New',
     '/hosts/view/(\d+)', 'wmt.controllers.hosts.View',
     '/hosts/edit/(\d+)', 'wmt.controllers.hosts.Edit',

--- a/wmt/__init__.py
+++ b/wmt/__init__.py
@@ -82,6 +82,7 @@ URLS = (
     '/run/visualize/(%s)' % _UUID_REGEX, 'wmt.controllers.run.VisualizeFile',
 
     '/package/create', 'wmt.controllers.package.Create',
+    '/package/delete/(%s)' % _UUID_REGEX, 'wmt.controllers.package.Delete',
 
     '/hosts/new', 'wmt.controllers.hosts.New',
     '/hosts/view/(\d+)', 'wmt.controllers.hosts.View',

--- a/wmt/controllers/package.py
+++ b/wmt/controllers/package.py
@@ -1,0 +1,69 @@
+import os
+import shutil
+import subprocess
+import json
+import web
+
+from ..render import render
+from ..validators import not_too_long, valid_uuid, submission_exists
+from ..config import site
+from ..utils.ssh import pickup_url
+
+
+class Create(object):
+
+    error_message = """ Unable to create tarball. This is either a bad
+simulation UUID or the simulation has not yet been staged.
+"""
+    form = web.form.Form(
+        web.form.Textbox('uuid',
+                         valid_uuid,
+                         submission_exists(),
+                         size=80,
+                         description='Simulation id:'),
+        web.form.Textbox('filename',
+                         not_too_long(512),
+                         size=80,
+                         description='Filename:'),
+        web.form.Button('Create')
+    )
+
+    def GET(self):
+        return render.titled_form('Create Tarball', self.form())
+
+    def POST(self):
+        form = self.form()
+        if not form.validates():
+            raise web.internalerror(self.error_message)
+
+        filename = form.d.filename
+        if len(filename) == 0:
+            filename = form.d.uuid
+
+        if not filename.endswith('.tar.gz'):
+            filename += '.tar.gz'
+
+        os.chdir(site['downloads'])
+
+        if not os.path.isdir(form.d.uuid):
+            raise web.internalerror(self.error_message)
+
+        try:
+            subprocess.check_call(['tar', '-zcf', filename, form.d.uuid])
+        except subprocess.CalledProcessError:
+            raise web.internalerror('Unable to create tarball.')
+
+        try:
+            shutil.copy(filename, site['pickup'])
+        except:
+            raise web.internalerror('Unable to copy tarball to pickup site.')
+        else:
+            os.remove(filename)
+
+        web.header('Content-Type', 'application/json; charset=utf-8')
+        return json.dumps({
+            'uuid': form.d.uuid,
+            'filename': filename,
+            'url': pickup_url(),
+        }, indent=2)
+

--- a/wmt/controllers/package.py
+++ b/wmt/controllers/package.py
@@ -8,11 +8,18 @@ from ..render import render
 from ..validators import not_too_long, valid_uuid, submission_exists
 from ..config import site
 from ..utils.ssh import pickup_url
+from .run import delete_tarball
+
+
+class Delete(object):
+    def POST(self, uuid):
+        delete_tarball(uuid)
+        return json.dumps(uuid)
 
 
 class Create(object):
 
-    error_message = """ Unable to create tarball. This is either a bad
+    error_message = """Unable to create tarball. This is either a bad
 simulation UUID or the simulation has not yet been staged.
 """
     form = web.form.Form(


### PR DESCRIPTION
The run/download API call fails with a server error for large downloads -- it times out or runs out of memory (not sure which) when making a tarball as a tempfile. This PR includes API calls to make/delete an actual tarball on the filesystem. The resulting workflow isn't as elegant. Instead of calling run/download and streaming the tarball, we need three steps:

1. create tarball with package/create API call
1. download tarball with requests.get() (or curl or whatever) from site['pickup']
1. delete tarball with package/delete
