### PR TITLE
Add API call to refresh a component

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -23,6 +23,7 @@ MAC_OS_NAME = {
 
 WMT_INI_CONTENTS = """
 [paths]
+bin = bin
 templates = templates
 files = files
 uploads = files/uploads

--- a/scripts/install
+++ b/scripts/install
@@ -33,6 +33,7 @@ database = %(db)s/wmt.db
 user_db = %(db)s/users.db
 submission_db = %(db)s/submission.db
 db = db
+opt = opt
 
 [url]
 scheme = {url_scheme}

--- a/wmt/__init__.py
+++ b/wmt/__init__.py
@@ -41,7 +41,8 @@ URLS = (
     '/components/input/(\w+)', 'wmt.controllers.components.Input',
     '/components/format/(\w+)', 'wmt.controllers.components.Format',
     '/components/command/(\w+)', 'wmt.controllers.components.Command',
-    '/components/refresh', 'wmt.controllers.components.Refresh',
+    '/components/refresh', 'wmt.controllers.components.RefreshAll',
+    '/components/refresh/(\w+)', 'wmt.controllers.components.Refresh',
 
     '/models/pretty-list', 'wmt.controllers.models.PrettyList',
     '/models/new', 'wmt.controllers.models.New',

--- a/wmt/__init__.py
+++ b/wmt/__init__.py
@@ -41,6 +41,7 @@ URLS = (
     '/components/input/(\w+)', 'wmt.controllers.components.Input',
     '/components/format/(\w+)', 'wmt.controllers.components.Format',
     '/components/command/(\w+)', 'wmt.controllers.components.Command',
+    '/components/refresh', 'wmt.controllers.components.Refresh',
 
     '/models/pretty-list', 'wmt.controllers.models.PrettyList',
     '/models/new', 'wmt.controllers.models.New',

--- a/wmt/__init__.py
+++ b/wmt/__init__.py
@@ -25,7 +25,6 @@ URLS = (
     '/tag/delete/(\d+)', 'wmt.controllers.tag.Delete',
     '/tag/get/(\d+)', 'wmt.controllers.tag.Get',
     '/tag/list', 'wmt.controllers.tag.List',
-
     '/tag/model/add', 'wmt.controllers.tag.TagModel',
     '/tag/model/remove', 'wmt.controllers.tag.UntagModel',
     '/tag/model/query', 'wmt.controllers.tag.Query',
@@ -34,7 +33,6 @@ URLS = (
     '/components/pretty-list', 'wmt.controllers.components.PrettyList',
     '/components/pretty-show/(\w+)', 'wmt.controllers.components.PrettyShow',
     '/components/pretty-params/(\w+)', 'wmt.controllers.components.PrettyParameters',
-
     '/components/list', 'wmt.controllers.components.List',
     '/components/dump', 'wmt.controllers.components.Dump',
     '/components/show/(\w+)', 'wmt.controllers.components.Show',
@@ -45,7 +43,6 @@ URLS = (
     '/components/command/(\w+)', 'wmt.controllers.components.Command',
 
     '/models/pretty-list', 'wmt.controllers.models.PrettyList',
-
     '/models/new', 'wmt.controllers.models.New',
     '/models/open/(\d+)', 'wmt.controllers.models.Open',
     '/models/save/(\d+)', 'wmt.controllers.models.Save',
@@ -59,7 +56,6 @@ URLS = (
     '/models/upload', 'wmt.controllers.models.Upload',
     '/models/validate', 'wmt.controllers.models.Validate',
     '/models/(-?\d+)/(\w+)/format', 'wmt.controllers.models.Format',
-
     '/models/convert', 'wmt.controllers.actions.Convert',
     '/models/submit', 'wmt.controllers.actions.Submit',
 

--- a/wmt/controllers/components.py
+++ b/wmt/controllers/components.py
@@ -138,3 +138,14 @@ class Command(object):
                 return render.code('> ' + ' '.join(comps.get_component_argv(name)))
         except KeyError:
             raise web.notfound()
+
+
+class Refresh(object):
+    def GET(self):
+        component_names = comps.get_component_names(sort=True)
+        for name in component_names:
+            hooks = comps.get_component_hooks(name)
+            hooks['refresh'].execute(name)
+
+        web.header('Content-Type', 'application/json; charset=utf-8')
+        return json.dumps('Components refreshed')

--- a/wmt/controllers/components.py
+++ b/wmt/controllers/components.py
@@ -160,4 +160,4 @@ class RefreshAll(object):
             refresh_component(name)
 
         web.header('Content-Type', 'application/json; charset=utf-8')
-        return json.dumps('All components refreshed')
+        return json.dumps(comps.get_component_names(sort=True), indent=indent)

--- a/wmt/controllers/components.py
+++ b/wmt/controllers/components.py
@@ -9,6 +9,11 @@ from ..validators import (not_too_long, not_too_short, not_bad_json)
 indent = 2
 
 
+def refresh_component(name):
+    hooks = comps.get_component_hooks(name)
+    hooks['refresh'].execute(name)
+
+
 class List(object):
     def GET(self):
         web.header('Content-Type', 'application/json; charset=utf-8')
@@ -141,11 +146,18 @@ class Command(object):
 
 
 class Refresh(object):
+    def GET(self, name):
+        refresh_component(name)
+
+        web.header('Content-Type', 'application/json; charset=utf-8')
+        return json.dumps('{} component refreshed'.format(name))
+
+
+class RefreshAll(object):
     def GET(self):
         component_names = comps.get_component_names(sort=True)
         for name in component_names:
-            hooks = comps.get_component_hooks(name)
-            hooks['refresh'].execute(name)
+            refresh_component(name)
 
         web.header('Content-Type', 'application/json; charset=utf-8')
-        return json.dumps('Components refreshed')
+        return json.dumps('All components refreshed')

--- a/wmt/models/components.py
+++ b/wmt/models/components.py
@@ -4,7 +4,7 @@ import json
 from ..config import palette, site, logger
 
 
-_HOOK_NAMES = set(['pre-stage', 'post-stage'])
+_HOOK_NAMES = set(['pre-stage', 'post-stage', 'refresh'])
 
 
 class Error(Exception):


### PR DESCRIPTION
I added two API calls, `components/refresh/(\w+)` (single component, by name) and `components/refresh` (all components). They simply call a component's `refresh` hook, if it exists. Note that if a hook doesn't exist, the API provides a dummy, so these calls should always return success.